### PR TITLE
Update connectionLogicHandler.js

### DIFF
--- a/tcp/connectionLogicHandler.js
+++ b/tcp/connectionLogicHandler.js
@@ -79,9 +79,6 @@ var tcpPackageConnection = require('./tcpPackageConnection')
 			, StartSubscription: function(message) {
 					this._subscriptions.scheduleSubscription(message, this._connection)
 				}
-			, StartConnection: function(message, cb) {
-					cb(null)
-				}
 			, TcpConnectionEstablished: noOp
 			}
 		, Closed: {


### PR DESCRIPTION
Hey, the start connection method is declared twice here.  This usually works but now I'm compiling with babel and it's throwing an error.  I have simply removed it presuming that it was not necessary.  If you need more from me let me know.
Thanks
r