### PR TITLE
Change protocol buffers library from protobuf to protobufjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "is": "^2.0.1",
     "node-uuid": "^1.4.1",
-    "protobuf": "^0.11.0",
+    "protobufjs": "^4.0.0",
     "request": "2.34.x"
   },
   "devDependencies": {

--- a/tcp/messageParser.js
+++ b/tcp/messageParser.js
@@ -1,23 +1,74 @@
-var fs = require('fs')
-	, path = require('path')
+var path = require('path')
 	, uuid = require('node-uuid')
-	, Schema = require('protobuf').Schema
-	, schema = new Schema(fs.readFileSync(path.resolve(__dirname, 'ges_client.desc')))
+	, protobuf = require('protobufjs')
+
+protobuf.convertFieldsToCamelCase = true
+protobuf.populateAccessors = false
+
+var builder = protobuf.loadProtoFile(path.resolve(__dirname, 'ges_client.proto'))
 	, messageNamespace = 'EventStore.Client.Messages.' 
+	, messages = builder.build('EventStore').Client.Messages
 
 module.exports = {
 	parse: parse
 , serialize: serialize
 }
 
-function getMessageHandler(messageName) {
-	return schema[messageNamespace + messageName]
+function getMessageClass(messageName) {
+	return messages[messageName]
 }
 
 function parse(messageName, payload) {
-  return getMessageHandler(messageName).parse(payload)
+	var MessageClass = getMessageClass(messageName)
+  return convertToClientObj(MessageClass.decode(payload).toRaw(false, true))
 }
 
 function serialize(messageName, message) {
-  return getMessageHandler(messageName).serialize(message)
+	var MessageClass = getMessageClass(messageName)
+	return new MessageClass(message).encode().toBuffer()
+}
+
+
+function isObject(obj) {
+	return Object.prototype.toString.call(obj) === '[object Object]'
+}
+
+
+function convertToClientObj(objToConvert) {
+	var convertedObj = Object.keys(objToConvert).reduce(function(obj, name) {
+		var val = objToConvert[name]
+			, type = getType(objToConvert, name)
+
+		if(type && isEnum(type)) {
+			obj[name] = getEnumValue(type, val)
+		} else if(protobuf.ByteBuffer.isByteBuffer(val)) {
+			obj[name] = val.toBuffer()
+		} else if(isObject(val)) {
+			obj[name] = convertToClientObj(val)
+		}
+
+		return obj
+	}, objToConvert)
+	return convertedObj
+}
+
+function getType(obj, name) {
+	if(!obj.$type) return null
+	if(!obj.$type.children) return null
+	var matchingChild = obj.$type.children.filter(function(child) {
+		return child.name === name
+	})[0]
+	return matchingChild && matchingChild.element ? matchingChild.element.resolvedType : null
+}
+
+function isEnum(type) {
+	return type && type.className === 'Enum' && type.children
+}
+
+function getEnumValue(enumType, rawValue) {
+	var enumValues = enumType.children.reduce(function(enums, val) {
+		enums[val.id] = val.name
+		return enums
+	}, {})
+	return enumValues[rawValue]
 }

--- a/tcp/operations.js
+++ b/tcp/operations.js
@@ -212,7 +212,7 @@ var operations = {
 					eventStreamId: operationData.stream
 				, fromEventNumber: payload.start
 				, maxCount: payload.count
-				, resolveLinkTaos: !!payload.resolveLinkTos
+				, resolveLinkTos: !!payload.resolveLinkTos
 				, requireMaster: !!payload.requireMaster
 		  	})
 	  	}

--- a/test/tcp/ges/isjson_flag_on_event.js
+++ b/test/tcp/ges/isjson_flag_on_event.js
@@ -21,14 +21,18 @@ describe('isjson_flag_on_event', function() {
 		})
 	})
 
+	function getData() {
+		return new Buffer(JSON.stringify({ some: 'json' }))
+	}
+
   it('should_be_preserved_with_all_possible_write_and_read_methods', function(done) {
     var stream = 'should_be_preserved_with_all_possible_write_methods'
     	, appendOptions = {
     			expectedVersion: client.expectedVersion.any
     		, events: [
-    				client.createEventData(uuid.v4(), 'some-type', true, { some: 'json' }, null)
-    			, client.createEventData(uuid.v4(), 'some-type', true, null, { some: 'json' })
-    			, client.createEventData(uuid.v4(), 'some-type', true, { some: 'json' }, { some: 'json' })
+    				client.createEventData(uuid.v4(), 'some-type', true, getData(), null)
+    			, client.createEventData(uuid.v4(), 'some-type', true, null, getData())
+    			, client.createEventData(uuid.v4(), 'some-type', true, getData(), getData())
     			]
 	    	}
 
@@ -41,9 +45,9 @@ describe('isjson_flag_on_event', function() {
     	connection.startTransaction(stream, transactionOptions, function(err, transaction) {
 	    	if(err) return done(err)
     		var events = [
-	    				client.createEventData(uuid.v4(), 'some-type', true, { some: 'json' }, null)
-	    			, client.createEventData(uuid.v4(), 'some-type', true, null, { some: 'json' })
-	    			, client.createEventData(uuid.v4(), 'some-type', true, { some: 'json' }, { some: 'json' })
+	    				client.createEventData(uuid.v4(), 'some-type', true, getData(), null)
+	    			, client.createEventData(uuid.v4(), 'some-type', true, null, getData())
+	    			, client.createEventData(uuid.v4(), 'some-type', true, getData(), getData())
 	    			]
 	    	transaction.write(events, function(err) {
 	    		if(err) return done(err)

--- a/test/tcp/ges/read_allevents_backward_with_linkto_deleted_event.js
+++ b/test/tcp/ges/read_allevents_backward_with_linkto_deleted_event.js
@@ -139,15 +139,14 @@ describe('read_allevents_backward_with_linkto_deleted_event', function() {
   	})
   })
 
-//BLM: This permanently fails, should it?
-  it('the_linked_event_is_not_resolved')/*, function(done) {
+  it('the_linked_event_is_not_resolved', function(done) {
   	connection.readStreamEventsBackward(linkedStreamName, readData, function(err, readResult) {
   		if(err) return done(err)
 
   		should.be.null(readResult.Events[0].Event)
   		done()
   	})
-  })*/
+  })
 
   it('the_link_event_is_included', function(done) {
   	connection.readStreamEventsBackward(linkedStreamName, readData, function(err, readResult) {

--- a/test/tcp/ges/transaction.js
+++ b/test/tcp/ges/transaction.js
@@ -262,7 +262,7 @@ describe('transaction', function() {
     	, transactionOptions = {
     			expectedVersion: client.expectedVersion.any
 	    	}
-	    , evt = client.createEventData(uuid.v4(), 'SomethingHappened', true, { Value: 42}, null)
+	    , evt = client.createEventData(uuid.v4(), 'SomethingHappened', true, new Buffer(JSON.stringify({ Value: 42 })), null)
 
     connection.startTransaction(stream, transactionOptions, function(err, transaction1) {
     	if(err) return done(err)


### PR DESCRIPTION
protobuf is dead, so to allow for newer versions of node, the library needed to be changed.

Also resolves #50.